### PR TITLE
add Keycloak to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ choose one of these to kick start your project.
 npm install
 npm run dev
 ```
+
+### Special hints for Keycloak
+
+If you consider using Keycloak please add these ENV variables:
+
+```sh
+npx convex env set KEYCLOAK_ISSUER https://keycloak.example.com/realms/master
+npx convex env set KEYCLOAK_CLIENT_SECRET super_save_keycloak_secret
+npx convex env set KEYCLOAK_CLIENT_ID client.id
+```

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,7 +18,6 @@ import type * as errors from "../errors.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as messages from "../messages.js";
-import type * as otp_FakePhone from "../otp/FakePhone.js";
 import type * as otp_ResendOTP from "../otp/ResendOTP.js";
 import type * as otp_TwilioOTP from "../otp/TwilioOTP.js";
 import type * as otp_TwilioSDK from "../otp/TwilioSDK.js";
@@ -42,7 +41,6 @@ declare const fullApi: ApiFromModules<{
   helpers: typeof helpers;
   http: typeof http;
   messages: typeof messages;
-  "otp/FakePhone": typeof otp_FakePhone;
   "otp/ResendOTP": typeof otp_ResendOTP;
   "otp/TwilioOTP": typeof otp_TwilioOTP;
   "otp/TwilioSDK": typeof otp_TwilioSDK;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -1,6 +1,7 @@
 import { INVALID_PASSWORD } from "./errors.js"
 import GitHub from "@auth/core/providers/github";
 import Google from "@auth/core/providers/google";
+import Keycloak from "@auth/core/providers/keycloak";
 import Resend from "@auth/core/providers/resend";
 import Apple from "@auth/core/providers/apple";
 import { Anonymous } from "@convex-dev/auth/providers/Anonymous";
@@ -23,6 +24,15 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
         token_endpoint_auth_method: "client_secret_post",
       },
       profile: undefined,
+    }),
+      Keycloak({
+      id: "keycloak",
+      name: "Keycloak",
+      wellKnown: "/.well-known/openid-configuration",
+      // you need to specify the keycloak realms path, i.e. https://keycloak.example.com/realms/master
+      issuer: `${process.env.KEYCLOAK_ISSUER}`,
+      clientSecret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
+      clientId: `${process.env.KEYCLOAK_CLIENT_ID}`,
     }),
     Resend({
       from: process.env.AUTH_EMAIL ?? "My App <onboarding@resend.dev>",
@@ -63,5 +73,6 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
     // This one only makes sense with routing, ignore for now:
     Password({ id: "password-link", verify: Resend }),
     Anonymous,
+
   ],
 });

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -25,15 +25,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
       },
       profile: undefined,
     }),
-      Keycloak({
-      id: "keycloak",
-      name: "Keycloak",
-      wellKnown: "/.well-known/openid-configuration",
-      // you need to specify the keycloak realms path, i.e. https://keycloak.example.com/realms/master
-      issuer: `${process.env.KEYCLOAK_ISSUER}`,
-      clientSecret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
-      clientId: `${process.env.KEYCLOAK_CLIENT_ID}`,
-    }),
+     
     Resend({
       from: process.env.AUTH_EMAIL ?? "My App <onboarding@resend.dev>",
     }),
@@ -73,6 +65,14 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
     // This one only makes sense with routing, ignore for now:
     Password({ id: "password-link", verify: Resend }),
     Anonymous,
-
+    Keycloak({
+      id: "keycloak",
+      name: "Keycloak",
+      wellKnown: "/.well-known/openid-configuration",
+      // you need to specify the keycloak realms path, i.e. https://keycloak.example.com/realms/master
+      issuer: `${process.env.KEYCLOAK_ISSUER}`,
+      clientSecret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
+      clientId: `${process.env.KEYCLOAK_CLIENT_ID}`,
+    }),
   ],
 });

--- a/src/auth/SignInWithOAuth.tsx
+++ b/src/auth/SignInWithOAuth.tsx
@@ -1,6 +1,7 @@
 import { SignInWithApple } from "@/auth/oauth/SignInWithApple";
 import { SignInWithGitHub } from "@/auth/oauth/SignInWithGitHub";
 import { SignInWithGoogle } from "@/auth/oauth/SignInWithGoogle";
+import { SignInWithKeycloak } from "./oauth/SignInWithKeycloak";
 
 export function SignInWithOAuth() {
   return (
@@ -8,6 +9,7 @@ export function SignInWithOAuth() {
       <SignInWithGitHub />
       <SignInWithGoogle />
       <SignInWithApple />
+      <SignInWithKeycloak />
     </div>
   );
 }

--- a/src/auth/oauth/SignInWithKeycloak.tsx
+++ b/src/auth/oauth/SignInWithKeycloak.tsx
@@ -1,0 +1,16 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { Button } from "@/components/ui/button";
+
+export function SignInWithKeycloak() {
+  const { signIn } = useAuthActions();
+  return (
+    <Button
+      className="flex-1"
+      variant="outline"
+      type="button"
+      onClick={() => void signIn("keycloak")}
+    >
+      Keycloak
+    </Button>
+  );
+}


### PR DESCRIPTION
Add Small Example for working Keycloak setup using the convex auth. 



I simply added a working Keycloak example setup and a button for easily test this integration.
----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
